### PR TITLE
Fix enquire link checks

### DIFF
--- a/smpp.go
+++ b/smpp.go
@@ -2,6 +2,7 @@ package smpp34
 
 import (
 	"bufio"
+	"crypto/tls"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -53,6 +54,26 @@ func NewSmppConnect(host string, port int) (*Smpp, error) {
 func (s *Smpp) Connect(host string, port int) (err error) {
 	s.conn, err = net.Dial("tcp", host+":"+strconv.Itoa(port))
 
+	return err
+}
+
+func NewSmppConnectTLS(host string, port int, config *tls.Config) (*Smpp, error) {
+	s := &Smpp{}
+
+	err := s.ConnectTLS(host, port, config)
+
+	return s, err
+}
+
+func (s *Smpp) ConnectTLS(host string, port int, config *tls.Config) error {
+	conn, err := net.Dial("tcp", host+":"+strconv.Itoa(port))
+	if err != nil {
+		return err
+	}
+	if config == nil {
+		config = &tls.Config{}
+	}
+	s.conn = tls.Client(conn, config)
 	return err
 }
 

--- a/smpp_test.go
+++ b/smpp_test.go
@@ -1,77 +1,129 @@
 package smpp34
 
 import (
+	"crypto/tls"
 	"encoding/hex"
-	"fmt"
-	. "launchpad.net/gocheck"
 	"net"
+	"strconv"
+	"testing"
 	"time"
 )
 
-func (x *MySuite) Test_Smpp(c *C) {
-	go startServer(c)
-	time.Sleep(1 * time.Second)
-
-	s, err := NewSmppConnect("localhost", 8080)
-
-	if err != nil {
-		fmt.Println("Connect Err:", err)
-		return
-	}
-
-	p, err := s.Bind(BIND_TRANSCEIVER, "test", "pass", &Params{})
-	if err != nil {
-		fmt.Println("Bind:", err)
-		return
-	}
-	s.Write(p)
-
-	p, err = s.Read()
-	if err != nil {
-		fmt.Println("BindResp:", err)
-		return
-	}
-
-	c.Check(p.GetHeader().Id, Equals, BIND_TRANSCEIVER_RESP)
-	c.Check(p.GetField(SYSTEM_ID).String(), Equals, "hugo")
-
-	_, err = s.Read()
-	c.Check(err, NotNil)
-	c.Check(err.Error(), Equals, "Unknown PDU Type. ID:2415919125")
-
-	_, err = s.Read()
-	c.Check(err, NotNil)
-	c.Check(err.Error(), Equals, "PDU Len different than read bytes")
-
-	_, err = s.Read()
-	c.Check(err, NotNil)
-	c.Check(err.Error(), Equals, "PDU Len larger than MAX_PDU_SIZE")
-
+func TestClient(t *testing.T) {
+	testClient(t, nil)
 }
 
-func startServer(c *C) {
-	ln, err := net.Listen("tcp", ":8080")
-
+func TestClientTLS(t *testing.T) {
+	cert, err := tls.X509KeyPair(localhostCert, localhostKey)
 	if err != nil {
-		// handle error
+		t.Fatal(err)
+	}
+	tc := tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+	testClient(t, &tc)
+}
+
+func testClient(t *testing.T, config *tls.Config) {
+	s, err := testServer(config)
+	if err != nil {
+		t.Fatal("Failed to parse host and port:", err)
+	}
+	defer s.Close()
+	host, port, err := s.Addr()
+	if err != nil {
+		t.Fatal("Failed parsing server addr:", err)
 	}
 
-	for {
-		conn, err := ln.Accept()
-		if err != nil {
-			// handle error
-			continue
+	var c *Smpp
+	if config == nil {
+		c, err = NewSmppConnect(host, port)
+	} else {
+		config.InsecureSkipVerify = true
+		c, err = NewSmppConnectTLS(host, port, config)
+	}
+	if err != nil {
+		t.Fatal("Failed to connect:", err)
+	}
+
+	p, err := c.Bind(BIND_TRANSCEIVER, "test", "pass", &Params{})
+	if err != nil {
+		t.Fatal("Failed to bind:", err)
+	}
+	c.Write(p)
+
+	p, err = c.Read()
+	if err != nil {
+		t.Fatal("Failed to read bind response:", err)
+	}
+
+	if v := p.GetHeader().Id; v != BIND_TRANSCEIVER_RESP {
+		t.Fatalf("Unexpected Id: want %q, have %q",
+			v, BIND_TRANSCEIVER_RESP)
+	}
+
+	if v := p.GetField(SYSTEM_ID).String(); v != "hugo" {
+		t.Fatalf("Unexpected SYSTEM_ID: want \"hugo\", have %q", v)
+	}
+	_, err = c.Read()
+	if err != nil && err.Error() != "Unknown PDU Type. ID:2415919125" {
+		t.Fatal("Unexpected error:", err)
+	}
+	_, err = c.Read()
+	if err != nil && err.Error() != "PDU Len different than read bytes" {
+		t.Fatal("Unexpected error:", err)
+	}
+	_, err = c.Read()
+	if err != nil && err.Error() != "PDU Len larger than MAX_PDU_SIZE" {
+		t.Fatal("Unexpected error:", err)
+	}
+}
+
+type server struct {
+	l net.Listener
+}
+
+func testServer(config *tls.Config) (*server, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	if config != nil {
+		l = tls.NewListener(l, config)
+	}
+	go func(l net.Listener) {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return // expected by Close
+			}
+			go handleConnection(conn)
 		}
-		go handleConnection(conn, c)
-	}
+	}(l)
+	return &server{l}, nil
 }
 
-func handleConnection(n net.Conn, c *C) {
+func (s *server) Addr() (host string, port int, err error) {
+	h, p, err := net.SplitHostPort(s.l.Addr().String())
+	if err != nil {
+		return "", 0, err
+	}
+	pn, err := strconv.Atoi(p)
+	if err != nil {
+		return "", 0, err
+	}
+	return h, pn, nil
+}
+
+func (s *server) Close() error {
+	return s.l.Close()
+}
+
+func handleConnection(n net.Conn) {
 	l := make([]byte, 1024)
 	_, err := n.Read(l)
-
 	if err != nil {
-		fmt.Println("server read error")
+		panic("server read error")
 	}
 
 	// Bind Resp
@@ -96,3 +148,40 @@ func handleConnection(n net.Conn, c *C) {
 	d, _ = hex.DecodeString("0000F01080000015000000005222b526")
 	n.Write(d)
 }
+
+// localhostCert is a PEM-encoded TLS cert with SAN IPs
+// "127.0.0.1" and "[::1]", expiring at the last second of 2049 (the end
+// of ASN.1 time).
+// generated from src/crypto/tls:
+// go run generate_cert.go  --rsa-bits 1024 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var localhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIICEzCCAXygAwIBAgIQMIMChMLGrR+QvmQvpwAU6zANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9SjY1bIw4
+iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZBl2+XsDul
+rKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQABo2gwZjAO
+BgNVHQ8BAf8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUw
+AwEB/zAuBgNVHREEJzAlggtleGFtcGxlLmNvbYcEfwAAAYcQAAAAAAAAAAAAAAAA
+AAAAATANBgkqhkiG9w0BAQsFAAOBgQCEcetwO59EWk7WiJsG4x8SY+UIAA+flUI9
+tyC4lNhbcF2Idq9greZwbYCqTTTr2XiRNSMLCOjKyI7ukPoPjo16ocHj+P3vZGfs
+h1fIw3cSS2OolhloGw/XM6RWPWtPAlGykKLciQrBru5NAPvCMsb/I1DAceTiotQM
+fblo6RBxUQ==
+-----END CERTIFICATE-----`)
+
+// localhostKey is the private key for localhostCert.
+var localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIICXgIBAAKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9
+SjY1bIw4iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZB
+l2+XsDulrKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQAB
+AoGAGRzwwir7XvBOAy5tM/uV6e+Zf6anZzus1s1Y1ClbjbE6HXbnWWF/wbZGOpet
+3Zm4vD6MXc7jpTLryzTQIvVdfQbRc6+MUVeLKwZatTXtdZrhu+Jk7hx0nTPy8Jcb
+uJqFk541aEw+mMogY/xEcfbWd6IOkp+4xqjlFLBEDytgbIECQQDvH/E6nk+hgN4H
+qzzVtxxr397vWrjrIgPbJpQvBsafG7b0dA4AFjwVbFLmQcj2PprIMmPcQrooz8vp
+jy4SHEg1AkEA/v13/5M47K9vCxmb8QeD/asydfsgS5TeuNi8DoUBEmiSJwma7FXY
+fFUtxuvL7XvjwjN5B30pNEbc6Iuyt7y4MQJBAIt21su4b3sjXNueLKH85Q+phy2U
+fQtuUE9txblTu14q3N7gHRZB4ZMhFYyDy8CKrN2cPg/Fvyt0Xlp/DoCzjA0CQQDU
+y2ptGsuSmgUtWj3NM9xuwYPm+Z/F84K6+ARYiZ6PYj013sovGKUFfYAqVXVlxtIX
+qyUBnu3X9ps8ZfjLZO7BAkEAlT4R5Yl6cGhaJQYZHOde3JEMhNRcVFMO8dJDaFeo
+f9Oeos0UUothgiDktdQHxdNEwLjQf7lJJBzV+5OtwswCWA==
+-----END RSA PRIVATE KEY-----`)

--- a/transceiver.go
+++ b/transceiver.go
@@ -1,6 +1,7 @@
 package smpp34
 
 import (
+	"crypto/tls"
 	"time"
 )
 
@@ -12,10 +13,31 @@ type Transceiver struct {
 	Err          error        // Errors generated in go routines that lead to conn close
 }
 
-// eli = EnquireLink Interval in Seconds
+// NewTransceiver creates and initializes a new Transceiver.
+// The eli parameter is for EnquireLink interval, in seconds.
 func NewTransceiver(host string, port int, eli int, bindParams Params) (*Transceiver, error) {
+	return newTransceiver(host, port, eli, bindParams, nil)
+}
+
+// NewTransceiver creates and initializes a new Transceiver using TLS.
+// The eli parameter is for EnquireLink interval, in seconds.
+func NewTransceiverTLS(host string, port int, eli int, bindParams Params, config *tls.Config) (*Transceiver, error) {
+	if config == nil {
+		config = &tls.Config{}
+	}
+	return newTransceiver(host, port, eli, bindParams, config)
+}
+
+// eli = EnquireLink Interval in Seconds
+func newTransceiver(host string, port int, eli int, bindParams Params, config *tls.Config) (*Transceiver, error) {
 	trx := &Transceiver{}
-	if err := trx.Connect(host, port); err != nil {
+	var err error
+	if config == nil {
+		err = trx.Connect(host, port)
+	} else {
+		err = trx.ConnectTLS(host, port, config)
+	}
+	if err != nil {
 		return nil, err
 	}
 

--- a/transmitter.go
+++ b/transmitter.go
@@ -184,8 +184,8 @@ func (t *Transmitter) Read() (Pdu, error) {
 			return nil, err
 		}
 	case ENQUIRE_LINK_RESP:
-		// Reset EnquireLink Check
-		t.eLCheckTimer.Reset(time.Duration(t.eLDuration) * time.Second)
+		// Stop EnquireLink Check.
+		t.eLCheckTimer.Stop()
 	case UNBIND:
 		t.UnbindResp(pdu.GetHeader().Sequence)
 		t.Close()

--- a/transmitter.go
+++ b/transmitter.go
@@ -1,6 +1,7 @@
 package smpp34
 
 import (
+	"crypto/tls"
 	"time"
 )
 
@@ -12,10 +13,29 @@ type Transmitter struct {
 	Err          error        // Errors generated in go routines that lead to conn close
 }
 
-// eli = EnquireLink Interval in Seconds
+// NewTransmitter creates and initializes a new Transmitter.
 func NewTransmitter(host string, port int, eli int, bindParams Params) (*Transmitter, error) {
+	return newTransmitter(host, port, eli, bindParams, nil)
+}
+
+// NewTransmitterTLs creates and initializes a new Transmitter using TLS.
+func NewTransmitterTLS(host string, port int, eli int, bindParams Params, config *tls.Config) (*Transmitter, error) {
+	if config == nil {
+		config = &tls.Config{}
+	}
+	return newTransmitter(host, port, eli, bindParams, config)
+}
+
+// eli = EnquireLink Interval in Seconds
+func newTransmitter(host string, port int, eli int, bindParams Params, config *tls.Config) (*Transmitter, error) {
 	tx := &Transmitter{}
-	if err := tx.Connect(host, port); err != nil {
+	var err error
+	if config == nil {
+		err = tx.Connect(host, port)
+	} else {
+		err = tx.ConnectTLS(host, port, config)
+	}
+	if err != nil {
 		return nil, err
 	}
 

--- a/transmitter.go
+++ b/transmitter.go
@@ -14,11 +14,13 @@ type Transmitter struct {
 }
 
 // NewTransmitter creates and initializes a new Transmitter.
+// The eli parameter is for EnquireLink interval, in seconds.
 func NewTransmitter(host string, port int, eli int, bindParams Params) (*Transmitter, error) {
 	return newTransmitter(host, port, eli, bindParams, nil)
 }
 
 // NewTransmitterTLs creates and initializes a new Transmitter using TLS.
+// The eli parameter is for EnquireLink interval, in seconds.
 func NewTransmitterTLS(host string, port int, eli int, bindParams Params, config *tls.Config) (*Transmitter, error) {
 	if config == nil {
 		config = &tls.Config{}


### PR DESCRIPTION
By resetting the timer it introduces a race condition to the next check
that hasn't been sent yet. Stopping seems to be the right thing to do
since the timer won't trigger anymore indicating a response has been
received.